### PR TITLE
json class and jq applied to its own results

### DIFF
--- a/R/jqr.R
+++ b/R/jqr.R
@@ -27,13 +27,13 @@ jq <- function(x, ...) {
 #' @export
 jq.jqr <- function(x, ...) {
   pipe_autoexec(toggle = FALSE)
-  structure(jqr(x$data, make_query(x)), class = "json")
+  structure(jqr(x$data, make_query(x)), class = c("json", "character"))
 }
 
 #' @rdname jq
 #' @export
 jq.character <- function(x, query, ...) {
-  structure(jqr(x, query), class = "json")
+  structure(jqr(x, query), class = c("json", "character"))
 }
 
 #' @export


### PR DESCRIPTION
This is just a small fix which adds "character" to the class of the jq results, so `jq` will work on its own result, e.g. this trivial example (which did not work before): `'{"a": 7}' %>% jq(".") %>% jq(".")`