### PR TITLE
Some minor changes

### DIFF
--- a/R/pipe_helpers.R
+++ b/R/pipe_helpers.R
@@ -47,8 +47,9 @@ pipe_autoexec <- function(toggle) {
   info <- pipeline_info()
 
   if (isTRUE(info[["is_piped"]])) {
+    jq_exit <- function(j) if (inherits(j, "jqr")) jq(j) else j
     pipeline_on_exit(info$env)
-    info$env$.jq_exitfun <- if (toggle) jq else identity
+    info$env$.jq_exitfun <- if (toggle) jq_exit else identity
   }
 
   invisible()

--- a/man/jq.Rd
+++ b/man/jq.Rd
@@ -10,14 +10,13 @@ jq(x, ...)
 
 \method{jq}{jqr}(x, ...)
 
-\method{jq}{character}(x, query, ...)
+\method{jq}{character}(x, ...)
 }
 \arguments{
 \item{x}{\code{json} object or character string with json data.}
 
-\item{...}{Not currently used.}
-
-\item{query}{(character) A query string}
+\item{...}{character specification of jq query. Each element in code{...}
+will be combined with " | ", which is convenient for long queries.}
 }
 \description{
 \code{jq} is meant to work with the high level interface in this package. \code{jq}


### PR DESCRIPTION
This PR has the following improvement:

* Robustness check in auto-execution, so a pipeline will only execute jq if the end-object inherits from `jqr`.

Therefore, e.g. 

```R
json %>% keys %>% str
```
will allow you to inspect the `jqr` object. Before this would give an error.
```R
(json %>% keys) %>% str
```

This, however, will execute (since its a nested pipeline) and `str` will inspect the resulting `json`.
Nothing special about `str` here, it's just an example.

**In addition**:
I suggest using `...` in the generic `jq` to construct low-level queries (combined with `" | "`). This will make long queries easier to pass in, but more importantly make a seamless connection between low-level and high-level calls:

```R
j %>% jq("keys") %>% dot
#> ["results","status"] 
j %>% keys %>% jq(".")
#> ["results","status"] 
```

This example, although not that long query, shows how one can use the `...`:

```R
lat_lng <- function(where)
{
  url <- sprintf("https://maps.googleapis.com/maps/api/geocode/json?address=%s",
                 where)
  
  (readLines(url)
   %>% paste(collapse = "")
   %>% jq(".results[] .geometry .location", 
          ".lat, .lng")
   %>% as.numeric
   %>% setNames(c("lat", "lng"))
  )
}


lat_lng("Copenhagen")
#>      lat      lng 
#> 55.67610 12.56834 
```