### PR TITLE
Improve make file

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@ man-roxygen
 ^CONDUCT\.md$
 cran-comments.md
 ^src/jq/.*\.o$
+^src/libjq.a$

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,9 @@
 .Rhistory
 .RData
 src/*.o
+src/jq/*.o
 src/*.so
+src/*.a
 jq-*.tar.gz
 jqr_*.tar.gz
 notes.md

--- a/src/Makevars
+++ b/src/Makevars
@@ -1,7 +1,4 @@
-# -*-makefile-*-
-OBJECTS = \
-	jqr.o \
-	RcppExports.o \
+LIBJQ = \
 	jq/builtin.o \
 	jq/bytecode.o \
 	jq/compile.o \
@@ -17,5 +14,12 @@ OBJECTS = \
 	jq/lexer.o \
 	jq/locfile.o \
 	jq/parser.o
+
+$(SHLIB): libjq.a
+
+libjq.a: $(LIBJQ)
+	$(AR) rcs libjq.a $(LIBJQ)
+
 PKG_CPPFLAGS = -Ijq
 PKG_CFLAGS = -Ijq
+PKG_LIBS = -L. -ljq


### PR DESCRIPTION
This decouples building jq from the bindings and links them later on. This has two benefits:
 
 - objects in jq which are not used by jqr do not end up in the shared library.
 - no need for patching illegal system calls in jq code... CMD check only inspects jqr code. 