### PR TITLE
Remove redundant flag

### DIFF
--- a/src/Makevars
+++ b/src/Makevars
@@ -21,5 +21,4 @@ libjq.a: $(LIBJQ)
 	$(AR) rcs libjq.a $(LIBJQ)
 
 PKG_CPPFLAGS = -Ijq
-PKG_CFLAGS = -Ijq
 PKG_LIBS = -L. -ljq


### PR DESCRIPTION
-I flags should only be passed to the preprocessor