### PR TITLE
CRAN warnings

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+jqr 0.3.0
+=========
+
+CRAN fixes:
+
+* Backport ec7c3cf (https://git.io/vwCFS)
+* Backport eb2fc1d (https://git.io/vwCF5)
+
 jqr 0.2.0
 ==============
 

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,0 +1,12 @@
+PKG_CPPFLAGS = -I../windows/jq-1.5/include
+PKG_LIBS = -L../windows/jq-1.5/lib${R_ARCH} -ljq -lonig -lshlwapi
+
+all: clean winlibs
+
+winlibs:
+	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
+
+clean:
+	rm -f $(OBJECTS) jqr.dll
+
+.PHONY: all clean winlibs

--- a/src/jq/execute.c
+++ b/src/jq/execute.c
@@ -52,7 +52,7 @@ struct frame {
   stack_ptr retdata;
   uint16_t* retaddr;
   /* bc->nclosures closures followed by bc->nlocals local variables */
-  union frame_entry entries[0]; 
+  union frame_entry entries[];
 };
 
 static int frame_size(struct bytecode* bc) {
@@ -108,7 +108,7 @@ static struct closure make_closure(struct jq_state* jq, uint16_t* pc) {
   }
 }
 
-static struct frame* frame_push(struct jq_state* jq, struct closure callee, 
+static struct frame* frame_push(struct jq_state* jq, struct closure callee,
                                 uint16_t* argdef, int nargs) {
   stack_ptr new_frame_idx = stack_push_block(&jq->stk, jq->curr_frame, frame_size(callee.bc));
   struct frame* new_frame = stack_block(&jq->stk, new_frame_idx);
@@ -180,7 +180,7 @@ void stack_save(jq_state *jq, uint16_t* retaddr, struct stack_pos sp){
   struct forkpoint* fork = stack_block(&jq->stk, jq->fork_top);
   fork->saved_data_stack = jq->stk_top;
   fork->saved_curr_frame = jq->curr_frame;
-  fork->path_len = 
+  fork->path_len =
     jv_get_kind(jq->path) == JV_KIND_ARRAY ? jv_array_length(jv_copy(jq->path)) : 0;
   fork->subexp_nest = jq->subexp_nest;
   fork->return_address = retaddr;
@@ -355,7 +355,7 @@ jv jq_next(jq_state *jq) {
       stack_push(jq, b);
       break;
     }
-      
+
     case POP: {
       jv_free(stack_pop(jq));
       break;
@@ -540,8 +540,8 @@ jv jq_next(jq_state *jq) {
       break;
     }
 
-    case EACH: 
-    case EACH_OPT: 
+    case EACH:
+    case EACH_OPT:
       stack_push(jq, jv_number(-1));
       // fallthrough
     case ON_BACKTRACK(EACH):
@@ -619,7 +619,7 @@ jv jq_next(jq_state *jq) {
       pc += offset;
       break;
     }
-      
+
     case CALL_BUILTIN: {
       int nargs = *pc++;
       jv top = stack_pop(jq);
@@ -642,7 +642,7 @@ jv jq_next(jq_state *jq) {
       case 5: top = ((func_5)function->fptr)(in[0], in[1], in[2], in[3], in[4]); break;
       default: return jv_invalid_with_msg(jv_string("Function takes too many arguments"));
       }
-      
+
       if (jv_is_valid(top)) {
         stack_push(jq, top);
       } else {
@@ -731,7 +731,7 @@ void jq_set_nomem_handler(jq_state *jq, void (*nomem_handler)(void *), void *dat
 void jq_start(jq_state *jq, jv input, int flags) {
   jv_nomem_handler(jq->nomem_handler, jq->nomem_handler_data);
   jq_reset(jq);
-  
+
   struct closure top = {jq->bc, -1};
   struct frame* top_frame = frame_push(jq, top, 0, 0);
   top_frame->retdata = 0;

--- a/src/jq/parser.c
+++ b/src/jq/parser.c
@@ -118,7 +118,7 @@ struct lexer_param;
       (Loc).end = YYRHSLOC(Rhs, 0).end;         \
     }                                           \
   } while (0)
- 
+
 
 #line 124 "parser.c" /* yacc.c:355  */
 
@@ -249,13 +249,13 @@ struct lexer_param {
     /*YYERROR*/;                                                   \
   } while (0)
 
-void yyerror(YYLTYPE* loc, block* answer, int* errors, 
+void yyerror(YYLTYPE* loc, block* answer, int* errors,
              struct locfile* locations, struct lexer_param* lexer_param_ptr, const char *s){
   (*errors)++;
   locfile_locate(locations, *loc, "error: %s", s);
 }
 
-int yylex(YYSTYPE* yylval, YYLTYPE* yylloc, block* answer, int* errors, 
+int yylex(YYSTYPE* yylval, YYLTYPE* yylloc, block* answer, int* errors,
           struct locfile* locations, struct lexer_param* lexer_param_ptr) {
   yyscan_t lexer = lexer_param_ptr->lexer;
   int tok = jq_yylex(yylval, yylloc, lexer);
@@ -317,7 +317,7 @@ static block gen_binop(block a, block b, int op) {
 }
 
 static block gen_format(block a, jv fmt) {
-  return BLOCK(a, gen_call("format", BLOCK(gen_lambda(gen_const(fmt)))));
+  return BLOCK(a, gen_call("format", gen_lambda(gen_const(fmt))));
 }
 
 static block gen_definedor_assign(block object, block val) {
@@ -325,16 +325,16 @@ static block gen_definedor_assign(block object, block val) {
   return BLOCK(gen_op_simple(DUP),
                val, tmp,
                gen_call("_modify", BLOCK(gen_lambda(object),
-                                         gen_lambda(gen_definedor(gen_noop(), 
+                                         gen_lambda(gen_definedor(gen_noop(),
                                                                   gen_op_bound(LOADV, tmp))))));
 }
- 
+
 static block gen_update(block object, block val, int optype) {
   block tmp = gen_op_var_fresh(STOREV, "tmp");
   return BLOCK(gen_op_simple(DUP),
                val,
                tmp,
-               gen_call("_modify", BLOCK(gen_lambda(object), 
+               gen_call("_modify", BLOCK(gen_lambda(object),
                                          gen_lambda(gen_binop(gen_noop(),
                                                               gen_op_bound(LOADV, tmp),
                                                               optype)))));
@@ -2194,16 +2194,16 @@ yyreduce:
 
   case 17:
 #line 267 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk)); 
+    {
+  (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk));
 }
 #line 2201 "parser.c" /* yacc.c:1646  */
     break;
 
   case 18:
 #line 271 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = gen_both((yyvsp[-2].blk), (yyvsp[0].blk)); 
+    {
+  (yyval.blk) = gen_both((yyvsp[-2].blk), (yyvsp[0].blk));
 }
 #line 2209 "parser.c" /* yacc.c:1646  */
     break;
@@ -2346,8 +2346,8 @@ yyreduce:
 
   case 36:
 #line 343 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = (yyvsp[0].blk); 
+    {
+  (yyval.blk) = (yyvsp[0].blk);
 }
 #line 2353 "parser.c" /* yacc.c:1646  */
     break;
@@ -2364,8 +2364,8 @@ yyreduce:
   case 38:
 #line 353 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_function(jv_string_value((yyvsp[-6].literal)), 
-                    gen_param(jv_string_value((yyvsp[-4].literal))), 
+  (yyval.blk) = gen_function(jv_string_value((yyvsp[-6].literal)),
+                    gen_param(jv_string_value((yyvsp[-4].literal))),
                     (yyvsp[-1].blk));
   jv_free((yyvsp[-6].literal));
   jv_free((yyvsp[-4].literal));
@@ -2376,8 +2376,8 @@ yyreduce:
   case 39:
 #line 361 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_function(jv_string_value((yyvsp[-8].literal)), 
-                    BLOCK(gen_param(jv_string_value((yyvsp[-6].literal))), 
+  (yyval.blk) = gen_function(jv_string_value((yyvsp[-8].literal)),
+                    BLOCK(gen_param(jv_string_value((yyvsp[-6].literal))),
                           gen_param(jv_string_value((yyvsp[-4].literal)))),
                     (yyvsp[-1].blk));
   jv_free((yyvsp[-8].literal));
@@ -2390,8 +2390,8 @@ yyreduce:
   case 40:
 #line 371 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_function(jv_string_value((yyvsp[-10].literal)), 
-                    BLOCK(gen_param(jv_string_value((yyvsp[-8].literal))), 
+  (yyval.blk) = gen_function(jv_string_value((yyvsp[-10].literal)),
+                    BLOCK(gen_param(jv_string_value((yyvsp[-8].literal))),
                           gen_param(jv_string_value((yyvsp[-6].literal))),
                           gen_param(jv_string_value((yyvsp[-4].literal)))),
                     (yyvsp[-1].blk));
@@ -2406,8 +2406,8 @@ yyreduce:
   case 41:
 #line 383 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_function(jv_string_value((yyvsp[-12].literal)), 
-                    BLOCK(gen_param(jv_string_value((yyvsp[-10].literal))), 
+  (yyval.blk) = gen_function(jv_string_value((yyvsp[-12].literal)),
+                    BLOCK(gen_param(jv_string_value((yyvsp[-10].literal))),
                           gen_param(jv_string_value((yyvsp[-8].literal))),
                           gen_param(jv_string_value((yyvsp[-6].literal))),
                           gen_param(jv_string_value((yyvsp[-4].literal)))),
@@ -2424,8 +2424,8 @@ yyreduce:
   case 42:
 #line 397 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_function(jv_string_value((yyvsp[-14].literal)), 
-                    BLOCK(gen_param(jv_string_value((yyvsp[-12].literal))), 
+  (yyval.blk) = gen_function(jv_string_value((yyvsp[-14].literal)),
+                    BLOCK(gen_param(jv_string_value((yyvsp[-12].literal))),
                           gen_param(jv_string_value((yyvsp[-10].literal))),
                           gen_param(jv_string_value((yyvsp[-8].literal))),
                           gen_param(jv_string_value((yyvsp[-6].literal))),
@@ -2444,8 +2444,8 @@ yyreduce:
   case 43:
 #line 413 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_function(jv_string_value((yyvsp[-16].literal)), 
-                    BLOCK(gen_param(jv_string_value((yyvsp[-14].literal))), 
+  (yyval.blk) = gen_function(jv_string_value((yyvsp[-16].literal)),
+                    BLOCK(gen_param(jv_string_value((yyvsp[-14].literal))),
                           gen_param(jv_string_value((yyvsp[-12].literal))),
                           gen_param(jv_string_value((yyvsp[-10].literal))),
                           gen_param(jv_string_value((yyvsp[-8].literal))),
@@ -2535,7 +2535,7 @@ yyreduce:
 
   case 53:
 #line 464 "parser.y" /* yacc.c:1646  */
-    { 
+    {
   (yyval.blk) = block_join((yyvsp[-2].blk), (yyvsp[0].blk));
 }
 #line 2542 "parser.c" /* yacc.c:1646  */
@@ -2560,7 +2560,7 @@ yyreduce:
   case 56:
 #line 476 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_noop(); 
+  (yyval.blk) = gen_noop();
 }
 #line 2566 "parser.c" /* yacc.c:1646  */
     break;
@@ -2583,8 +2583,8 @@ yyreduce:
 
   case 59:
 #line 485 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = gen_index_opt(gen_noop(), gen_const((yyvsp[-1].literal))); 
+    {
+  (yyval.blk) = gen_index_opt(gen_noop(), gen_const((yyvsp[-1].literal)));
 }
 #line 2590 "parser.c" /* yacc.c:1646  */
     break;
@@ -2615,8 +2615,8 @@ yyreduce:
 
   case 63:
 #line 497 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = gen_index(gen_noop(), gen_const((yyvsp[0].literal))); 
+    {
+  (yyval.blk) = gen_index(gen_noop(), gen_const((yyvsp[0].literal)));
 }
 #line 2622 "parser.c" /* yacc.c:1646  */
     break;
@@ -2659,7 +2659,7 @@ yyreduce:
   case 68:
 #line 516 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_index_opt((yyvsp[-4].blk), (yyvsp[-2].blk)); 
+  (yyval.blk) = gen_index_opt((yyvsp[-4].blk), (yyvsp[-2].blk));
 }
 #line 2665 "parser.c" /* yacc.c:1646  */
     break;
@@ -2667,7 +2667,7 @@ yyreduce:
   case 69:
 #line 519 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_index((yyvsp[-3].blk), (yyvsp[-1].blk)); 
+  (yyval.blk) = gen_index((yyvsp[-3].blk), (yyvsp[-1].blk));
 }
 #line 2673 "parser.c" /* yacc.c:1646  */
     break;
@@ -2675,7 +2675,7 @@ yyreduce:
   case 70:
 #line 522 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = block_join((yyvsp[-3].blk), gen_op_simple(EACH_OPT)); 
+  (yyval.blk) = block_join((yyvsp[-3].blk), gen_op_simple(EACH_OPT));
 }
 #line 2681 "parser.c" /* yacc.c:1646  */
     break;
@@ -2683,7 +2683,7 @@ yyreduce:
   case 71:
 #line 525 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = block_join((yyvsp[-2].blk), gen_op_simple(EACH)); 
+  (yyval.blk) = block_join((yyvsp[-2].blk), gen_op_simple(EACH));
 }
 #line 2689 "parser.c" /* yacc.c:1646  */
     break;
@@ -2739,7 +2739,7 @@ yyreduce:
   case 78:
 #line 546 "parser.y" /* yacc.c:1646  */
     {
-  (yyval.blk) = gen_const((yyvsp[0].literal)); 
+  (yyval.blk) = gen_const((yyvsp[0].literal));
 }
 #line 2745 "parser.c" /* yacc.c:1646  */
     break;
@@ -2762,31 +2762,31 @@ yyreduce:
 
   case 81:
 #line 555 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = (yyvsp[-1].blk); 
+    {
+  (yyval.blk) = (yyvsp[-1].blk);
 }
 #line 2769 "parser.c" /* yacc.c:1646  */
     break;
 
   case 82:
 #line 558 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = gen_collect((yyvsp[-1].blk)); 
+    {
+  (yyval.blk) = gen_collect((yyvsp[-1].blk));
 }
 #line 2777 "parser.c" /* yacc.c:1646  */
     break;
 
   case 83:
 #line 561 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk) = gen_const(jv_array()); 
+    {
+  (yyval.blk) = gen_const(jv_array());
 }
 #line 2785 "parser.c" /* yacc.c:1646  */
     break;
 
   case 84:
 #line 564 "parser.y" /* yacc.c:1646  */
-    { 
+    {
   (yyval.blk) = BLOCK(gen_subexp(gen_const(jv_object())), (yyvsp[-1].blk), gen_op_simple(POP));
 }
 #line 2793 "parser.c" /* yacc.c:1646  */
@@ -2896,8 +2896,8 @@ yyreduce:
 
   case 97:
 #line 611 "parser.y" /* yacc.c:1646  */
-    { 
-  (yyval.blk)=gen_noop(); 
+    {
+  (yyval.blk)=gen_noop();
 }
 #line 2903 "parser.c" /* yacc.c:1646  */
     break;
@@ -2922,7 +2922,7 @@ yyreduce:
 
   case 101:
 #line 619 "parser.y" /* yacc.c:1646  */
-    { 
+    {
   (yyval.blk) = gen_dictpair(gen_const((yyvsp[-2].literal)), (yyvsp[0].blk));
  }
 #line 2929 "parser.c" /* yacc.c:1646  */

--- a/src/jq/parser.y
+++ b/src/jq/parser.y
@@ -107,13 +107,13 @@ struct lexer_param {
     /*YYERROR*/;                                                   \
   } while (0)
 
-void yyerror(YYLTYPE* loc, block* answer, int* errors, 
+void yyerror(YYLTYPE* loc, block* answer, int* errors,
              struct locfile* locations, struct lexer_param* lexer_param_ptr, const char *s){
   (*errors)++;
   locfile_locate(locations, *loc, "error: %s", s);
 }
 
-int yylex(YYSTYPE* yylval, YYLTYPE* yylloc, block* answer, int* errors, 
+int yylex(YYSTYPE* yylval, YYLTYPE* yylloc, block* answer, int* errors,
           struct locfile* locations, struct lexer_param* lexer_param_ptr) {
   yyscan_t lexer = lexer_param_ptr->lexer;
   int tok = jq_yylex(yylval, yylloc, lexer);
@@ -175,7 +175,7 @@ static block gen_binop(block a, block b, int op) {
 }
 
 static block gen_format(block a, jv fmt) {
-  return BLOCK(a, gen_call("format", BLOCK(gen_lambda(gen_const(fmt)))));
+  return BLOCK(a, gen_call("format", gen_lambda(gen_const(fmt))));
 }
 
 static block gen_definedor_assign(block object, block val) {
@@ -183,16 +183,16 @@ static block gen_definedor_assign(block object, block val) {
   return BLOCK(gen_op_simple(DUP),
                val, tmp,
                gen_call("_modify", BLOCK(gen_lambda(object),
-                                         gen_lambda(gen_definedor(gen_noop(), 
+                                         gen_lambda(gen_definedor(gen_noop(),
                                                                   gen_op_bound(LOADV, tmp))))));
 }
- 
+
 static block gen_update(block object, block val, int optype) {
   block tmp = gen_op_var_fresh(STOREV, "tmp");
   return BLOCK(gen_op_simple(DUP),
                val,
                tmp,
-               gen_call("_modify", BLOCK(gen_lambda(object), 
+               gen_call("_modify", BLOCK(gen_lambda(object),
                                          gen_lambda(gen_binop(gen_noop(),
                                                               gen_op_bound(LOADV, tmp),
                                                               optype)))));
@@ -207,7 +207,7 @@ Exp {
 } |
 FuncDefs {
   *answer = $1;
-} 
+}
 
 FuncDefs:
 /* empty */ {
@@ -246,7 +246,7 @@ Exp '=' Exp {
 
 Exp "or" Exp {
   $$ = gen_or($1, $3);
-} | 
+} |
 
 Exp "and" Exp {
   $$ = gen_and($1, $3);
@@ -264,12 +264,12 @@ Exp "|=" Exp {
   $$ = gen_call("_modify", BLOCK(gen_lambda($1), gen_lambda($3)));
 } |
 
-Exp '|' Exp { 
-  $$ = block_join($1, $3); 
+Exp '|' Exp {
+  $$ = block_join($1, $3);
 } |
 
-Exp ',' Exp { 
-  $$ = gen_both($1, $3); 
+Exp ',' Exp {
+  $$ = gen_both($1, $3);
 } |
 
 Exp '+' Exp {
@@ -340,8 +340,8 @@ Exp ">=" Exp {
   $$ = gen_binop($1, $3, GREATEREQ);
 } |
 
-Term { 
-  $$ = $1; 
+Term {
+  $$ = $1;
 }
 
 FuncDef:
@@ -351,16 +351,16 @@ FuncDef:
 } |
 
 "def" IDENT '(' IDENT ')' ':' Exp ';' {
-  $$ = gen_function(jv_string_value($2), 
-                    gen_param(jv_string_value($4)), 
+  $$ = gen_function(jv_string_value($2),
+                    gen_param(jv_string_value($4)),
                     $7);
   jv_free($2);
   jv_free($4);
 } |
 
 "def" IDENT '(' IDENT ';' IDENT ')' ':' Exp ';' {
-  $$ = gen_function(jv_string_value($2), 
-                    BLOCK(gen_param(jv_string_value($4)), 
+  $$ = gen_function(jv_string_value($2),
+                    BLOCK(gen_param(jv_string_value($4)),
                           gen_param(jv_string_value($6))),
                     $9);
   jv_free($2);
@@ -369,8 +369,8 @@ FuncDef:
 } |
 
 "def" IDENT '(' IDENT ';' IDENT ';' IDENT ')' ':' Exp ';' {
-  $$ = gen_function(jv_string_value($2), 
-                    BLOCK(gen_param(jv_string_value($4)), 
+  $$ = gen_function(jv_string_value($2),
+                    BLOCK(gen_param(jv_string_value($4)),
                           gen_param(jv_string_value($6)),
                           gen_param(jv_string_value($8))),
                     $11);
@@ -381,8 +381,8 @@ FuncDef:
 } |
 
 "def" IDENT '(' IDENT ';' IDENT ';' IDENT ';' IDENT ')' ':' Exp ';' {
-  $$ = gen_function(jv_string_value($2), 
-                    BLOCK(gen_param(jv_string_value($4)), 
+  $$ = gen_function(jv_string_value($2),
+                    BLOCK(gen_param(jv_string_value($4)),
                           gen_param(jv_string_value($6)),
                           gen_param(jv_string_value($8)),
                           gen_param(jv_string_value($10))),
@@ -395,8 +395,8 @@ FuncDef:
 } |
 
 "def" IDENT '(' IDENT ';' IDENT ';' IDENT ';' IDENT ';' IDENT ')' ':' Exp ';' {
-  $$ = gen_function(jv_string_value($2), 
-                    BLOCK(gen_param(jv_string_value($4)), 
+  $$ = gen_function(jv_string_value($2),
+                    BLOCK(gen_param(jv_string_value($4)),
                           gen_param(jv_string_value($6)),
                           gen_param(jv_string_value($8)),
                           gen_param(jv_string_value($10)),
@@ -411,8 +411,8 @@ FuncDef:
 } |
 
 "def" IDENT '(' IDENT ';' IDENT ';' IDENT ';' IDENT ';' IDENT ';' IDENT ')' ':' Exp ';' {
-  $$ = gen_function(jv_string_value($2), 
-                    BLOCK(gen_param(jv_string_value($4)), 
+  $$ = gen_function(jv_string_value($2),
+                    BLOCK(gen_param(jv_string_value($4)),
                           gen_param(jv_string_value($6)),
                           gen_param(jv_string_value($8)),
                           gen_param(jv_string_value($10)),
@@ -461,7 +461,7 @@ ElseBody:
 }
 
 ExpD:
-ExpD '|' ExpD { 
+ExpD '|' ExpD {
   $$ = block_join($1, $3);
 } |
 '-' ExpD {
@@ -474,7 +474,7 @@ Term {
 
 Term:
 '.' {
-  $$ = gen_noop(); 
+  $$ = gen_noop();
 } |
 REC {
   $$ = gen_call("recurse_down", gen_noop());
@@ -482,8 +482,8 @@ REC {
 Term FIELD '?' {
   $$ = gen_index_opt($1, gen_const($2));
 } |
-FIELD '?' { 
-  $$ = gen_index_opt(gen_noop(), gen_const($1)); 
+FIELD '?' {
+  $$ = gen_index_opt(gen_noop(), gen_const($1));
 } |
 Term '.' String '?' {
   $$ = gen_index_opt($1, $3);
@@ -494,8 +494,8 @@ Term '.' String '?' {
 Term FIELD {
   $$ = gen_index($1, gen_const($2));
 } |
-FIELD { 
-  $$ = gen_index(gen_noop(), gen_const($1)); 
+FIELD {
+  $$ = gen_index(gen_noop(), gen_const($1));
 } |
 Term '.' String {
   $$ = gen_index($1, $3);
@@ -511,19 +511,19 @@ Term '.' String {
   jv_free($2);
   FAIL(@$, "try .[\"field\"] instead of .field for unusually named fields");
   $$ = gen_noop();
-} | 
+} |
 /* FIXME: string literals */
 Term '[' Exp ']' '?' {
-  $$ = gen_index_opt($1, $3); 
+  $$ = gen_index_opt($1, $3);
 } |
 Term '[' Exp ']' {
-  $$ = gen_index($1, $3); 
+  $$ = gen_index($1, $3);
 } |
 Term '[' ']' '?' {
-  $$ = block_join($1, gen_op_simple(EACH_OPT)); 
+  $$ = block_join($1, gen_op_simple(EACH_OPT));
 } |
 Term '[' ']' {
-  $$ = block_join($1, gen_op_simple(EACH)); 
+  $$ = block_join($1, gen_op_simple(EACH));
 } |
 Term '[' Exp ':' Exp ']' '?' {
   $$ = gen_slice_index($1, $3, $5, INDEX_OPT);
@@ -544,7 +544,7 @@ Term '[' ':' Exp ']' {
   $$ = gen_slice_index($1, gen_const(jv_null()), $4, INDEX);
 } |
 LITERAL {
-  $$ = gen_const($1); 
+  $$ = gen_const($1);
 } |
 String {
   $$ = $1;
@@ -552,22 +552,22 @@ String {
 FORMAT {
   $$ = gen_format(gen_noop(), $1);
 } |
-'(' Exp ')' { 
-  $$ = $2; 
-} | 
-'[' Exp ']' { 
-  $$ = gen_collect($2); 
+'(' Exp ')' {
+  $$ = $2;
 } |
-'[' ']' { 
-  $$ = gen_const(jv_array()); 
+'[' Exp ']' {
+  $$ = gen_collect($2);
 } |
-'{' MkDict '}' { 
+'[' ']' {
+  $$ = gen_const(jv_array());
+} |
+'{' MkDict '}' {
   $$ = BLOCK(gen_subexp(gen_const(jv_object())), $2, gen_op_simple(POP));
 } |
 '$' IDENT {
   $$ = gen_location(@$, gen_op_unbound(LOADV, jv_string_value($2)));
   jv_free($2);
-} | 
+} |
 IDENT {
   $$ = gen_location(@$, gen_call(jv_string_value($1), gen_noop()));
   jv_free($1);
@@ -608,15 +608,15 @@ Term '[' error ']' { $$ = $1; } |
 '{' error '}' { $$ = gen_noop(); }
 
 MkDict:
-{ 
-  $$=gen_noop(); 
+{
+  $$=gen_noop();
 } |
  MkDictPair { $$ = $1; }
 | MkDictPair ',' MkDict { $$=block_join($1, $3); }
 | error ',' MkDict { $$ = $3; }
 
 MkDictPair
-: IDENT ':' ExpD { 
+: IDENT ':' ExpD {
   $$ = gen_dictpair(gen_const($1), $3);
  }
 | String ':' ExpD {

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,0 +1,8 @@
+# Build against mingw-w64 build of jq 1.5
+if(!file.exists("../windows/jq-1.5/include/jq.h")){
+  if(getRversion() < "3.3.0") setInternet2()
+  download.file("https://github.com/rwinlib/jq/archive/v1.5.zip", "lib.zip", quiet = TRUE)
+  dir.create("../windows", showWarnings = FALSE)
+  unzip("lib.zip", exdir = "../windows")
+  unlink("lib.zip")
+}


### PR DESCRIPTION
This fixes the "significant warnings" from https://github.com/ropensci/jqr/issues/42. That should make CRAN happy for now.

Fixing jq for solaris or ubsan would require major work and it not worth it if we are going to switch to system libjq soon. But there are many packages with solaris/ubsan issues, so I think this is fine for now.
