### PR TITLE
Backport fixes for CRAN

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,11 @@
+jqr 0.3.0
+=========
+
+Fixes for CRAN:
+
+* Backport ec7c3cf (https://git.io/vwCFS)
+* Backport eb2fc1d (https://git.io/vwCF5)
+
 jqr 0.2.0
 ==============
 

--- a/src/jq/execute.c
+++ b/src/jq/execute.c
@@ -52,7 +52,7 @@ struct frame {
   stack_ptr retdata;
   uint16_t* retaddr;
   /* bc->nclosures closures followed by bc->nlocals local variables */
-  union frame_entry entries[0]; 
+  union frame_entry entries[]; 
 };
 
 static int frame_size(struct bytecode* bc) {

--- a/src/jq/parser.c
+++ b/src/jq/parser.c
@@ -317,7 +317,7 @@ static block gen_binop(block a, block b, int op) {
 }
 
 static block gen_format(block a, jv fmt) {
-  return BLOCK(a, gen_call("format", BLOCK(gen_lambda(gen_const(fmt)))));
+  return BLOCK(a, gen_call("format", gen_lambda(gen_const(fmt))));
 }
 
 static block gen_definedor_assign(block object, block val) {

--- a/src/jq/parser.y
+++ b/src/jq/parser.y
@@ -175,7 +175,7 @@ static block gen_binop(block a, block b, int op) {
 }
 
 static block gen_format(block a, jv fmt) {
-  return BLOCK(a, gen_call("format", BLOCK(gen_lambda(gen_const(fmt)))));
+  return BLOCK(a, gen_call("format", gen_lambda(gen_const(fmt))));
 }
 
 static block gen_definedor_assign(block object, block val) {


### PR DESCRIPTION
This fixes the "significant warnings" from https://github.com/ropensci/jqr/issues/42. That should make CRAN happy for now.

Fixing jq for solaris or ubsan would require major work and it not worth it if we are going to switch to system libjq soon. But there are many packages with solaris/ubsan issues, so this should be fine for now.
