### PR TITLE
Compatibility with magrittr 2.0

### DIFF
--- a/R/pipe_helpers.R
+++ b/R/pipe_helpers.R
@@ -89,3 +89,5 @@ pipeline_on_exit <- function(env) {
 
   do.call(on.exit, list(as.call(list(exit_clo)), add = TRUE), envir = env)
 }
+
+utils::globalVariables(".jq_exitfun")


### PR DESCRIPTION
We're about to release magrittr 2.0 and a jqr failure appeared in our last round of revdep checks. I'm not sure why it didn't show up earlier, so I'm sorry for the late heads up.

The internals have changed and this is causing issues for `pipeline_on_exit()`. I've come up with a workaround using `on.exit()` `returnValue()`, and `return()`. This works with both magrittr 1.5 and 2.0.

Note that the `pipeline_info()` routine is not 100% correct and in some circumstances might change the return value in unintended frames. More generally, changing the return value of a pipeline from downstack is a bit magical and might cause confusion for R users trying to understand the semantics of their tools. Finally, this will not work with the base pipe to be included in R 4.1.